### PR TITLE
Upgrade to support mip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,14 @@ Supported Python Versions
 
 TinyDB has been tested with Python 3.5 - 3.8, PyPy and Micropython.
 
+Installation
+************
+.. code-block:: python
+
+    >>> import mip
+    >>> mip.install("github:ahmadmicro/tinydb")
+
+
 Example Code
 ************
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "urls": [
-    ["tinydb/__init__.py", "github:ThinkTransit/tinydb/tinydb/__init__.py"]
-    ["tinydb/database.py", "github:ThinkTransit/tinydb/tinydb/database.py"]
-    ["tinydb/middlewares.py", "github:ThinkTransit/tinydb/tinydb/middlewares.py"]
-    ["tinydb/operations.py", "github:ThinkTransit/tinydb/tinydb/operations.py"]
-    ["tinydb/py.typed", "github:ThinkTransit/tinydb/tinydb/py.typed"]
-    ["tinydb/queries.py", "github:ThinkTransit/tinydb/tinydb/queries.py"]
-    ["tinydb/storages.py", "github:ThinkTransit/tinydb/tinydb/storages.py"]
-    ["tinydb/table.py", "github:ThinkTransit/tinydb/tinydb/table.py"]
-    ["tinydb/utils.py", "github:ThinkTransit/tinydb/tinydb/utils.py"]
-    ["tinydb/version.py", "github:ThinkTransit/tinydb/tinydb/version.py"]
+    ["tinydb/__init__.py", "github:ahmadmicro/tinydb/tinydb/__init__.py"]
+    ["tinydb/database.py", "github:ahmadmicro/tinydb/tinydb/database.py"]
+    ["tinydb/middlewares.py", "github:ahmadmicro/tinydb/tinydb/middlewares.py"]
+    ["tinydb/operations.py", "github:ahmadmicro/tinydb/tinydb/operations.py"]
+    ["tinydb/py.typed", "github:ahmadmicro/tinydb/tinydb/py.typed"]
+    ["tinydb/queries.py", "github:ahmadmicro/tinydb/tinydb/queries.py"]
+    ["tinydb/storages.py", "github:ahmadmicro/tinydb/tinydb/storages.py"]
+    ["tinydb/table.py", "github:ahmadmicro/tinydb/tinydb/table.py"]
+    ["tinydb/utils.py", "github:ahmadmicro/tinydb/tinydb/utils.py"]
+    ["tinydb/version.py", "github:ahmadmicro/tinydb/tinydb/version.py"]
     
   ],
   "deps": [

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "urls": [
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/__init__.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/database.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/middlewares.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/operations.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/py.typed"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/queries.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/storages.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/table.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/utils.py"]
-    ["tinydb", "github:ThinkTransit/tinydb/tinydb/version.py"]
+    ["tinydb/__init__.py", "github:ThinkTransit/tinydb/tinydb/__init__.py"]
+    ["tinydb/database.py", "github:ThinkTransit/tinydb/tinydb/database.py"]
+    ["tinydb/middlewares.py", "github:ThinkTransit/tinydb/tinydb/middlewares.py"]
+    ["tinydb/operations.py", "github:ThinkTransit/tinydb/tinydb/operations.py"]
+    ["tinydb/py.typed", "github:ThinkTransit/tinydb/tinydb/py.typed"]
+    ["tinydb/queries.py", "github:ThinkTransit/tinydb/tinydb/queries.py"]
+    ["tinydb/storages.py", "github:ThinkTransit/tinydb/tinydb/storages.py"]
+    ["tinydb/table.py", "github:ThinkTransit/tinydb/tinydb/table.py"]
+    ["tinydb/utils.py", "github:ThinkTransit/tinydb/tinydb/utils.py"]
+    ["tinydb/version.py", "github:ThinkTransit/tinydb/tinydb/version.py"]
     
   ],
   "deps": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "urls": [
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/__init__.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/database.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/middlewares.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/operations.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/py.typed"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/queries.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/storages.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/table.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/utils.py"]
+    ["tinydb", "github:ThinkTransit/tinydb/tinydb/version.py"]
+    
+  ],
+  "deps": [
+  ],
+  "version": "4.4.0"
+}


### PR DESCRIPTION
Hi,

The attached pr will upgrade your port to support mip.

The user will be able to install the package using

```python
import mip
mip.install('github:ahmadmicro/tinydb')
```

You can test it using my fork
```python
import mip
mip.install('github:ThinkTransit/tinydb', version='mip-upgrade')
```
